### PR TITLE
Fix so CSS gets included in header for Redmine 1.2.0

### DIFF
--- a/app/helpers/redmine_markdown_extra_formatter/helper.rb
+++ b/app/helpers/redmine_markdown_extra_formatter/helper.rb
@@ -3,8 +3,13 @@ module RedmineMarkdownExtraFormatter
     unloadable
 
     def wikitoolbar_for(field_id)
-      url = Redmine::Utils.relative_url_root +
-        Engines::RailsExtensions::AssetHelpers.plugin_asset_path('redmine_markdown_extra_formatter', 'help', 'markdown_extra_syntax.html')
+      heads_for_wiki_formatter
+
+      # Only way we have to link to a public resource.(?)
+      #url = "#{Redmine::Utils.relative_url_root}/help/wiki_syntax.html"
+
+      url = Engines::RailsExtensions::AssetHelpers.plugin_asset_path('redmine_markdown_extra_formatter', 'help', 'markdown_extra_syntax.html')
+
       help_link = l(:setting_text_formatting) + ': ' +
         link_to(l(:label_help), url,
         :onclick => "window.open(\"#{url}\", \"\", \"resizable=yes, location=no, width=300, height=640, menubar=no, status=no, scrollbars=yes\"); return false;")
@@ -21,8 +26,14 @@ module RedmineMarkdownExtraFormatter
     end
 
     def heads_for_wiki_formatter
-      stylesheet_link_tag('jstoolbar') +
-        stylesheet_link_tag('markdown_extra', :plugin => 'redmine_markdown_extra_formatter')
+      unless @heads_for_wiki_formatter_included
+        content_for :header_tags do
+          stylesheet_link_tag('jstoolbar') +
+          stylesheet_link_tag('markdown_extra', :plugin => 'redmine_markdown_extra_formatter')
+        end
+        @heads_for_wiki_formatter_included = true
+      end
     end
+
   end
 end


### PR DESCRIPTION
The previous `heads_for_wiki_formatter` function is not getting called by Redmine's `layouts/base.rhtml`. (see Redmine [r5239](http://www.redmine.org/projects/redmine/repository/revisions/5239))

Patch also takes advantage of changes that permit this plugin's CSS to be included only on pages that have wiki editing boxes on them. (See the [textile helper.rb](http://www.redmine.org/projects/redmine/repository/revisions/5239/entry/trunk/lib/redmine/wiki_formatting/textile/helper.rb) file.)

Also reverted how we generate the URL to the syntax help page - it seems Rails 2.3.11 fixes the previous behavior, and non-standard install locations get properly referenced.
