### PR TITLE
Adds Bundler support

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,3 @@
+source :rubygems
+
+gem "bluefeather"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,10 @@
+GEM
+  remote: http://rubygems.org/
+  specs:
+    bluefeather (0.40)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  bluefeather


### PR DESCRIPTION
Adds `Gemfile` and `Gemfile.lock` to the repository to handle the bluefeather dependency.

I added this to allow the latest [Redmine](http://redmine.org) version which uses Bundler.
